### PR TITLE
Add simple website using Tailwind and Dify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to .env and provide your Dify settings
+DIFY_APP_ID=
+DIFY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # ChatCV
+
+Simple AI chatbot website powered by [Dify](https://dify.ai). The frontend uses HTML and Tailwind CSS.
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your `DIFY_APP_ID` and `DIFY_API_KEY`.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm start
+   ```
+   The site will be available at `http://localhost:3000`.
+
+## Project Structure
+
+- `website/index.html` – main webpage with Tailwind styling and Dify chat widget.
+- `server.js` – small Express server that injects environment variables.
+- `.env.example` – example file for environment configuration.
+
+## Screenshots
+
+![screenshot](./screenshot.png)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "chatcv",
+  "version": "1.0.0",
+  "description": "Chatbot website using Dify",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.static('website'));
+
+app.get('/config.js', (req, res) => {
+  res.type('application/javascript');
+  res.send(`window.DIFY_APP_ID = "${process.env.DIFY_APP_ID || ''}";\nwindow.DIFY_API_KEY = "${process.env.DIFY_API_KEY || ''}";`);
+});
+
+app.listen(port, () => {
+  console.log(`ChatCV server running at http://localhost:${port}`);
+});

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ChatCV</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/config.js"></script>
+</head>
+<body class="bg-gray-900 text-white min-h-screen flex flex-col">
+    <header class="bg-gradient-to-r from-purple-500 to-indigo-600 p-6 text-center">
+        <h1 class="text-4xl font-bold">ChatCV AI</h1>
+        <p class="mt-2 text-gray-200">Your resume powered chatbot</p>
+    </header>
+    <main class="flex-grow container mx-auto p-4">
+        <div id="chat-container" class="rounded-lg shadow-lg bg-gray-800 p-4 h-[70vh] overflow-y-auto">
+            <!-- Dify chat widget will appear here -->
+        </div>
+    </main>
+    <footer class="text-center p-4 text-sm text-gray-400">
+        &copy; 2024 ChatCV
+    </footer>
+
+    <script>
+        const difyAppId = window.DIFY_APP_ID;
+        const difyApiKey = window.DIFY_API_KEY;
+        if (!difyAppId || !difyApiKey) {
+            document.getElementById('chat-container').innerText = 'Dify configuration missing.';
+        } else {
+            const script = document.createElement('script');
+            script.src = `https://udify.app/chat/widget/${difyAppId}.js`;
+            script.setAttribute('data-api-key', difyApiKey);
+            script.defer = true;
+            document.body.appendChild(script);
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a minimal Tailwind page for the chatbot
- serve config from environment variables using Express
- document setup and add example env file

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683fe5ccd2a0832092110df780bc5688